### PR TITLE
102 project

### DIFF
--- a/havoc/__init__.py
+++ b/havoc/__init__.py
@@ -152,8 +152,8 @@ class Connect:
                 'tfstate_dynamodb_table': tfstate_dynamodb_table
             }
         }
-        create_deployment_response = self.post(self.manage_api_endpoint, payload)
-        return create_deployment_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
     
     def update_deployment(self, **kwargs):
         payload = {
@@ -164,25 +164,27 @@ class Connect:
             payload['detail'] = kwargs
         else:
             payload['detail'] = {}
-        update_deployment_response = self.post(self.manage_api_endpoint, payload)
-        return update_deployment_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
     
     def get_deployment(self):
         payload = {
             'resource': 'deployment',
             'command': 'get',
         }
-        get_deployment_response = self.post(self.manage_api_endpoint, payload)
-        return get_deployment_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
-    def list_tasks(self, task_name_contains='', task_status='running'):
+    def list_tasks(self, task_name_contains='', task_status='running', task_type=None):
         payload = {
             'resource': 'task',
             'command': 'list',
             'detail': {'task_name_contains': task_name_contains, 'task_status': task_status}
         }
-        list_tasks_response = self.post(self.manage_api_endpoint, payload)
-        return list_tasks_response
+        if task_type:
+            payload['detail']['task_type'] = task_type
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def get_task(self, task_name):
         payload = {
@@ -190,8 +192,8 @@ class Connect:
             'command': 'get',
             'detail': {'task_name': task_name}
         }
-        get_task_response = self.post(self.manage_api_endpoint, payload)
-        return get_task_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def kill_task(self, task_name):
         payload = {
@@ -199,16 +201,16 @@ class Connect:
             'command': 'kill',
             'detail': {'task_name': task_name}
         }
-        kill_task_response = self.post(self.manage_api_endpoint, payload)
-        return kill_task_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def list_task_types(self):
         payload = {
             'resource': 'task_type',
             'command': 'list'
         }
-        list_task_types_response = self.post(self.manage_api_endpoint, payload)
-        return list_task_types_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def get_task_type(self, task_type):
         payload = {
@@ -216,8 +218,8 @@ class Connect:
             'command': 'get',
             'detail': {'task_type': task_type}
         }
-        get_task_type_response = self.post(self.manage_api_endpoint, payload)
-        return get_task_type_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def create_task_type(self, task_type, task_version, source_image, capabilities, cpu, memory):
         payload = {
@@ -232,8 +234,8 @@ class Connect:
                 'memory': memory
             }
         }
-        create_task_type_response = self.post(self.manage_api_endpoint, payload)
-        return create_task_type_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def delete_task_type(self, task_type):
         payload = {
@@ -241,16 +243,16 @@ class Connect:
             'command': 'delete',
             'detail': {'task_type': task_type}
         }
-        delete_task_type_response = self.post(self.manage_api_endpoint, payload)
-        return delete_task_type_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def list_triggers(self):
         payload = {
             'resource': 'trigger',
             'command': 'list'
         }
-        list_triggers_response = self.post(self.manage_api_endpoint, payload)
-        return list_triggers_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def get_trigger(self, trigger_name):
         payload = {
@@ -258,8 +260,8 @@ class Connect:
             'command': 'get',
             'detail': {'trigger_name': trigger_name}
         }
-        get_trigger_response = self.post(self.manage_api_endpoint, payload)
-        return get_trigger_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def create_trigger(self, trigger_name, schedule_expression, execute_command, execute_command_args=None, execute_command_timeout=None,
                        filter_command=None, filter_command_args=None, filter_command_timeout=None):
@@ -277,8 +279,8 @@ class Connect:
                 'filter_command_timeout': filter_command_timeout
             }
         }
-        create_trigger_response = self.post(self.manage_api_endpoint, payload)
-        return create_trigger_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
     
     def delete_trigger(self, trigger_name):
         payload = {
@@ -286,16 +288,16 @@ class Connect:
             'command': 'delete',
             'detail': {'trigger_name': trigger_name}
         }
-        delete_trigger_response = self.post(self.manage_api_endpoint, payload)
-        return delete_trigger_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
     
     def list_users(self):
         payload = {
             'resource': 'user',
             'command': 'list'
         }
-        list_users_response = self.post(self.manage_api_endpoint, payload)
-        return list_users_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def get_user(self, user_id):
         payload = {
@@ -303,8 +305,8 @@ class Connect:
             'command': 'get',
             'detail': {'user_id': user_id}
         }
-        get_user_response = self.post(self.manage_api_endpoint, payload)
-        return get_user_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def create_user(self, user_id, admin=None, remote_task=None, task_name=None):
         payload = {
@@ -312,8 +314,8 @@ class Connect:
             'command': 'create',
             'detail': {'user_id': user_id, 'admin': admin, 'remote_task': remote_task, 'task_name': task_name}
         }
-        create_user_response = self.post(self.manage_api_endpoint, payload)
-        return create_user_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def update_user(self, user_id, new_user_id=None, admin=None, remote_task=None, task_name=None, reset_keys=None):
         detail = {'user_id': user_id}
@@ -332,8 +334,8 @@ class Connect:
             'command': 'update',
             'detail': detail
         }
-        update_user_response = self.post(self.manage_api_endpoint, payload)
-        return update_user_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def delete_user(self, user_id):
         payload = {
@@ -341,8 +343,8 @@ class Connect:
             'command': 'delete',
             'detail': {'user_id': user_id}
         }
-        delete_user_response = self.post(self.manage_api_endpoint, payload)
-        return delete_user_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def list_files(self, path=None):
         payload = {
@@ -352,38 +354,38 @@ class Connect:
         }
         if path:
             payload['detail']['path'] = path
-        list_files_response = self.post(self.manage_api_endpoint, payload)
-        return list_files_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def get_file(self, path, file_name):
         payload = {
             'resource': 'workspace',
             'command': 'get',
-            'detail': {'path': path, 'filename': file_name}
+            'detail': {'path': path, 'file_name': file_name}
         }
-        get_file_response = self.post(self.manage_api_endpoint, payload)
-        decoded_file = base64.b64decode(get_file_response['file_contents'])
-        get_file_response['file_contents'] = decoded_file
-        return get_file_response
+        response = self.post(self.manage_api_endpoint, payload)
+        decoded_file = base64.b64decode(response['file_contents'])
+        response['file_contents'] = decoded_file
+        return response
 
     def create_file(self, path, file_name, raw_file):
         encoded_file = base64.b64encode(raw_file).decode()
         payload = {
             'resource': 'workspace',
             'command': 'create',
-            'detail': {'path': path, 'filename': file_name, 'file_contents': encoded_file}
+            'detail': {'path': path, 'file_name': file_name, 'file_contents': encoded_file}
         }
-        create_file_response = self.post(self.manage_api_endpoint, payload)
-        return create_file_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def delete_file(self, path, file_name):
         payload = {
             'resource': 'workspace',
             'command': 'delete',
-            'detail': {'path': path, 'filename': file_name}
+            'detail': {'path': path, 'file_name': file_name}
         }
-        delete_file_response = self.post(self.manage_api_endpoint, payload)
-        return delete_file_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def list_playbooks(self, playbook_name_contains='', playbook_status='all'):
         payload = {
@@ -391,8 +393,8 @@ class Connect:
             'command': 'list',
             'detail': {'playbook_name_contains': playbook_name_contains, 'playbook_status': playbook_status}
         }
-        list_playbooks_response = self.post(self.manage_api_endpoint, payload)
-        return list_playbooks_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
     
     def get_playbook(self, playbook_name):
         payload = {
@@ -400,8 +402,8 @@ class Connect:
             'command': 'get',
             'detail': {'playbook_name': playbook_name}
         }
-        get_playbook_response = self.post(self.manage_api_endpoint, payload)
-        return get_playbook_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
     
     def create_playbook(self, playbook_name, playbook_type, playbook_timeout, playbook_config):
         payload = {
@@ -414,8 +416,8 @@ class Connect:
                 'playbook_config': playbook_config
             }
         }
-        create_playbook_response = self.post(self.manage_api_endpoint, payload)
-        return create_playbook_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
     
     def delete_playbook(self, playbook_name):
         payload = {
@@ -423,8 +425,8 @@ class Connect:
             'command': 'delete',
             'detail': {'playbook_name': playbook_name}
         }
-        delete_playbook_response = self.post(self.manage_api_endpoint, payload)
-        return delete_playbook_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
     
     def kill_playbook(self, playbook_name):
         payload = {
@@ -432,8 +434,8 @@ class Connect:
             'command': 'kill',
             'detail': {'playbook_name': playbook_name}
         }
-        kill_playbook_response = self.post(self.manage_api_endpoint, payload)
-        return kill_playbook_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
     
     def run_playbook(self, playbook_name, playbook_type=None, playbook_config=None, playbook_timeout=None):
         payload = {
@@ -446,36 +448,36 @@ class Connect:
             payload['detail']['playbook_config'] = playbook_config
         if playbook_timeout:
             payload['detail']['playbook_timeout'] = playbook_timeout
-        run_playbook_response = self.post(self.playbook_operator_control_api_endpoint, payload)
-        return run_playbook_response
+        response = self.post(self.playbook_operator_control_api_endpoint, payload)
+        return response
     
     def get_playbook_results(self, playbook_name, operator_command=None, start_time=None, end_time=None):
         payload = {
             'action': 'get_results',
             'detail': {'playbook_name': playbook_name, 'start_time': start_time, 'end_time': end_time}
         }
-        get_playbook_results_response = self.post(self.playbook_operator_control_api_endpoint, payload)
-        if 'queue' not in get_playbook_results_response:
-            return get_playbook_results_response
+        response = self.post(self.playbook_operator_control_api_endpoint, payload)
+        if 'queue' not in response:
+            return response
         filtered_results = []
         if not operator_command:
-            for result in get_playbook_results_response['queue']:
+            for result in response['queue']:
                 filtered_results.append(result)
         if operator_command:
-            for result in get_playbook_results_response['queue']:
+            for result in response['queue']:
                 if result['operator_command'] == operator_command:
                     filtered_results.append(result)
-        del get_playbook_results_response['queue']
-        get_playbook_results_response['queue'] = filtered_results
-        return get_playbook_results_response
+        del response['queue']
+        response['queue'] = filtered_results
+        return response
     
     def list_playbook_types(self):
         payload = {
             'resource': 'playbook_type',
             'command': 'list'
         }
-        list_playbook_types_response = self.post(self.manage_api_endpoint, payload)
-        return list_playbook_types_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def get_playbook_type(self, playbook_type):
         payload = {
@@ -483,8 +485,8 @@ class Connect:
             'command': 'get',
             'detail': {'playbook_type': playbook_type}
         }
-        get_playbook_type_response = self.post(self.manage_api_endpoint, payload)
-        return get_playbook_type_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def create_playbook_type(self, playbook_type, playbook_version, playbook_template):
         payload = {
@@ -496,8 +498,8 @@ class Connect:
                 'playbook_template': playbook_template,
             }
         }
-        create_playbook_type_response = self.post(self.manage_api_endpoint, payload)
-        return create_playbook_type_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def delete_playbook_type(self, playbook_type):
         payload = {
@@ -505,16 +507,16 @@ class Connect:
             'command': 'delete',
             'detail': {'playbook_type': playbook_type}
         }
-        delete_playbook_type_response = self.post(self.manage_api_endpoint, payload)
-        return delete_playbook_type_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
     
     def list_portgroups(self):
         payload = {
             'resource': 'portgroup',
             'command': 'list'
         }
-        list_portgroups_response = self.post(self.manage_api_endpoint, payload)
-        return list_portgroups_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def get_portgroup(self, portgroup_name):
         payload = {
@@ -522,8 +524,8 @@ class Connect:
             'command': 'get',
             'detail': {'portgroup_name': portgroup_name}
         }
-        get_portgroup_response = self.post(self.manage_api_endpoint, payload)
-        return get_portgroup_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def create_portgroup(self, portgroup_name, portgroup_description):
         payload = {
@@ -531,8 +533,8 @@ class Connect:
             'command': 'create',
             'detail': {'portgroup_name': portgroup_name, 'portgroup_description': portgroup_description}
         }
-        create_portgroup_response = self.post(self.manage_api_endpoint, payload)
-        return create_portgroup_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def update_portgroup_rule(self, portgroup_name, portgroup_action, ip_ranges, port, ip_protocol):
         payload = {
@@ -546,8 +548,8 @@ class Connect:
                 'ip_protocol': ip_protocol
             }
         }
-        update_portgroup_rule_response = self.post(self.manage_api_endpoint, payload)
-        return update_portgroup_rule_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def delete_portgroup(self, portgroup_name):
         payload = {
@@ -555,16 +557,16 @@ class Connect:
             'command': 'delete',
             'detail': {'portgroup_name': portgroup_name}
         }
-        delete_portgroup_response = self.post(self.manage_api_endpoint, payload)
-        return delete_portgroup_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def list_domains(self):
         payload = {
             'resource': 'domain',
             'command': 'list'
         }
-        list_domains_response = self.post(self.manage_api_endpoint, payload)
-        return list_domains_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def get_domain(self, domain_name):
         payload = {
@@ -572,8 +574,8 @@ class Connect:
             'command': 'get',
             'detail': {'domain_name': domain_name}
         }
-        get_domain_response = self.post(self.manage_api_endpoint, payload)
-        return get_domain_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def create_domain(self, domain_name, hosted_zone):
         payload = {
@@ -581,8 +583,8 @@ class Connect:
             'command': 'create',
             'detail': {'domain_name': domain_name, 'hosted_zone': hosted_zone}
         }
-        create_domain_response = self.post(self.manage_api_endpoint, payload)
-        return create_domain_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def delete_domain(self, domain_name):
         payload = {
@@ -590,16 +592,16 @@ class Connect:
             'command': 'delete',
             'detail': {'domain_name': domain_name}
         }
-        delete_domain_response = self.post(self.manage_api_endpoint, payload)
-        return delete_domain_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
     
     def list_listeners(self):
         payload = {
             'resource': 'listener',
             'command': 'list'
         }
-        list_listeners_response = self.post(self.manage_api_endpoint, payload)
-        return list_listeners_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def get_listener(self, listener_name):
         payload = {
@@ -607,8 +609,8 @@ class Connect:
             'command': 'get',
             'detail': {'listener_name': listener_name}
         }
-        get_listener_response = self.post(self.manage_api_endpoint, payload)
-        return get_listener_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def create_listener(self, listener_name, listener_config, task_name, portgroups, host_name=None, domain_name=None):
         payload = {
@@ -623,8 +625,8 @@ class Connect:
                 'domain_name': domain_name
             }
         }
-        create_listener_response = self.post(self.manage_api_endpoint, payload)
-        return create_listener_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
     def delete_listener(self, listener_name):
         payload = {
@@ -632,43 +634,10 @@ class Connect:
             'command': 'delete',
             'detail': {'listener_name': listener_name}
         }
-        delete_listener_response = self.post(self.manage_api_endpoint, payload)
-        return delete_listener_response
+        response = self.post(self.manage_api_endpoint, payload)
+        return response
 
-    def list_workspace_get_urls(self, filename=None):
-        payload = {
-            'resource': 'workspace_access',
-            'command': 'list',
-            'detail': {}
-        }
-        if filename:
-            payload['detail']['filename'] = filename
-        list_workspace_get_urls_response = self.post(self.workspace_access_get_api_endpoint, payload)
-        return list_workspace_get_urls_response
-
-    def get_workspace_get_url(self, filename):
-        payload = {
-            'resource': 'workspace_access',
-            'command': 'get',
-            'detail': {'filename': filename}
-        }
-        get_workspace_get_url_response = self.post(self.workspace_access_get_api_endpoint, payload)
-        return get_workspace_get_url_response
-
-    def create_workspace_get_url(self, filename, expiration=None):
-        payload = {
-            'resource': 'workspace_access',
-            'command': 'create',
-            'detail': {
-                'filename': filename
-            }
-        }
-        if expiration:
-            payload['detail']['expiration'] = expiration
-        create_workspace_get_url_response = self.post(self.workspace_access_get_api_endpoint, payload)
-        return create_workspace_get_url_response
-
-    def list_workspace_put_urls(self, path=None, filename=None):
+    def list_workspace_get_urls(self, path=None, file_name=None):
         payload = {
             'resource': 'workspace_access',
             'command': 'list',
@@ -676,33 +645,63 @@ class Connect:
         }
         if path:
             payload['detail']['path'] = path
-        if filename:
-            payload['detail']['filename'] = filename
-        list_workspace_put_urls_response = self.post(self.workspace_access_put_api_endpoint, payload)
-        return list_workspace_put_urls_response
+        if file_name:
+            payload['detail']['file_name'] = file_name
+        response = self.post(self.workspace_access_get_api_endpoint, payload)
+        return response
 
-    def get_workspace_put_url(self, path, filename):
+    def get_workspace_get_url(self, path, file_name):
         payload = {
             'resource': 'workspace_access',
             'command': 'get',
-            'detail': {'path': path, 'filename': filename}
+            'detail': {'path': path, 'file_name': file_name}
         }
-        get_workspace_put_url_response = self.post(self.workspace_access_put_api_endpoint, payload)
-        return get_workspace_put_url_response
+        response = self.post(self.workspace_access_get_api_endpoint, payload)
+        return response
 
-    def create_workspace_put_url(self, path, filename, expiration=None):
+    def create_workspace_get_url(self, path, file_name, expiration=None):
         payload = {
             'resource': 'workspace_access',
             'command': 'create',
-            'detail': {
-                'path': path,
-                'filename': filename
-            }
+            'detail': {'path': path, 'file_name': file_name}
         }
         if expiration:
             payload['detail']['expiration'] = expiration
-        create_workspace_put_url_response = self.post(self.workspace_access_put_api_endpoint, payload)
-        return create_workspace_put_url_response
+        response = self.post(self.workspace_access_get_api_endpoint, payload)
+        return response
+
+    def list_workspace_put_urls(self, path=None, file_name=None):
+        payload = {
+            'resource': 'workspace_access',
+            'command': 'list',
+            'detail': {}
+        }
+        if path:
+            payload['detail']['path'] = path
+        if file_name:
+            payload['detail']['file_name'] = file_name
+        response = self.post(self.workspace_access_put_api_endpoint, payload)
+        return response
+
+    def get_workspace_put_url(self, path, file_name):
+        payload = {
+            'resource': 'workspace_access',
+            'command': 'get',
+            'detail': {'path': path, 'file_name': file_name}
+        }
+        response = self.post(self.workspace_access_put_api_endpoint, payload)
+        return response
+
+    def create_workspace_put_url(self, path, file_name, expiration=None):
+        payload = {
+            'resource': 'workspace_access',
+            'command': 'create',
+            'detail': {'path': path, 'file_name': file_name}
+        }
+        if expiration:
+            payload['detail']['expiration'] = expiration
+        response = self.post(self.workspace_access_put_api_endpoint, payload)
+        return response
     
     def run_task(self, task_name, task_type, task_host_name='None', task_domain_name='None', portgroups=['None'],
                  end_time='None'):
@@ -717,8 +716,8 @@ class Connect:
                 'end_time': end_time
             }
         }
-        run_task_response = self.post(self.task_control_api_endpoint, payload)
-        return run_task_response
+        response = self.post(self.task_control_api_endpoint, payload)
+        return response
 
     def instruct_task(self, task_name, instruct_instance, instruct_command, instruct_args=None):
         payload = {
@@ -731,42 +730,42 @@ class Connect:
         }
         if instruct_args:
             payload['detail']['instruct_args'] = instruct_args
-        instruct_task_response = self.post(self.task_control_api_endpoint, payload)
-        return instruct_task_response
+        response = self.post(self.task_control_api_endpoint, payload)
+        return response
 
     def get_task_results(self, task_name, instruct_command=None, instruct_instance=None, start_time=None, end_time=None):
         payload = {
             'action': 'get_results',
             'detail': {'task_name': task_name, 'start_time': start_time, 'end_time': end_time}
         }
-        get_task_results_response = self.post(self.task_control_api_endpoint, payload)
-        if 'queue' not in get_task_results_response:
-            return get_task_results_response
+        response = self.post(self.task_control_api_endpoint, payload)
+        if 'queue' not in response:
+            return response
         filtered_results = []
         if not instruct_command and not instruct_instance:
-            for result in get_task_results_response['queue']:
+            for result in response['queue']:
                 filtered_results.append(result)
         if instruct_command and not instruct_instance:
-            for result in get_task_results_response['queue']:
+            for result in response['queue']:
                 if result['instruct_command'] == instruct_command:
                     filtered_results.append(result)
         if instruct_instance and not instruct_command:
-            for result in get_task_results_response['queue']:
+            for result in response['queue']:
                 if result['instruct_instance'] == instruct_instance:
                     filtered_results.append(result)
         if instruct_command and instruct_instance:
-            for result in get_task_results_response['queue']:
+            for result in response['queue']:
                 if result['instruct_command'] == instruct_command and result['instruct_instance'] == instruct_instance:
                     filtered_results.append(result)
-        del get_task_results_response['queue']
-        get_task_results_response['queue'] = filtered_results
-        return get_task_results_response
+        del response['queue']
+        response['queue'] = filtered_results
+        return response
 
     def task_startup(self, task_name, task_type, task_host_name='None', task_domain_name='None', portgroups=['None'],
                  end_time='None'):
-        run_task_response = self.run_task(task_name, task_type, task_host_name, task_domain_name, portgroups, end_time)
-        if run_task_response['outcome'] != 'success':
-            return run_task_response
+        response = self.run_task(task_name, task_type, task_host_name, task_domain_name, portgroups, end_time)
+        if response['outcome'] != 'success':
+            return response
         task_status = None
         task_details = None
         while task_status != 'idle':
@@ -779,10 +778,10 @@ class Connect:
         command_finished = None
         instruct_instance = ''.join(random.choice(string.ascii_letters) for i in range(6))
         instruct_command = 'terminate'
-        instruct_task_response = self.instruct_task(task_name, instruct_instance, instruct_command)
-        if instruct_task_response['outcome'] != 'success':
-            return instruct_task_response
-        instruct_id = instruct_task_response['instruct_id']
+        response = self.instruct_task(task_name, instruct_instance, instruct_command)
+        if response['outcome'] != 'success':
+            return response
+        instruct_id = response['instruct_id']
         while not command_finished:
             instruct_results = self.get_task_results(task_name)
             if 'queue' in instruct_results:
@@ -835,58 +834,112 @@ class Connect:
             return interaction
         return results
     
-    def run_session_command(self, task_name, session_id, session_command, end_strings=None, timeout=None, timeout_exception=None, instruct_instance=None):
-        instruct_command = 'run_session_command'
-        instruct_args = {'session_id': session_id, 'session_command': session_command, 'end_strings': end_strings, 'timeout': timeout, 'timeout_exception': timeout_exception}
-        run_session_command_response = self.interact_with_task(task_name, instruct_command, instruct_instance, instruct_args)
-        return run_session_command_response
+    def run_metasploit_session_command(self, task_name, session_id, session_command, wait_time=None, instruct_instance=None):
+        instruct_command = 'run_metasploit_session_command'
+        instruct_args = {'session_id': session_id, 'metasploit_session_command': session_command, 'wait_time': wait_time}
+        response = self.interact_with_task(task_name, instruct_command, instruct_instance, instruct_args)
+        return response
     
-    def run_session_shell_command(self, task_name, session_id, session_shell_command, wait_time=None, instruct_instance=None):
-        instruct_command = 'run_session_shell_command'
-        instruct_args = {'session_id': session_id, 'session_shell_command': session_shell_command, 'wait_time': wait_time}
-        run_session_command_response = self.interact_with_task(task_name, instruct_command, instruct_instance, instruct_args)
-        return run_session_command_response
+    def run_metasploit_session_shell_command(self, task_name, session_id, session_shell_command, wait_time=None, instruct_instance=None):
+        instruct_command = 'run_metasploit_session_shell_command'
+        instruct_args = {'session_id': session_id, 'metasploit_session_shell_command': session_shell_command, 'wait_time': wait_time}
+        response = self.interact_with_task(task_name, instruct_command, instruct_instance, instruct_args)
+        return response
     
-    def kill_session(self, task_name, session_id, instruct_instance=None):
-        instruct_command = 'kill_session'
+    def list_metasploit_sessions(self, task_name=None):
+        sessions_list = []
+        list_tasks_response = self.list_tasks(task_name_contains=task_name, task_type='metasploit')
+        if len(list_tasks_response['tasks']) != 0:
+            for task in list_tasks_response['tasks']:
+                task_name=task['task_name']
+                instruct_command = 'list_metasploit_sessions'
+                list_sessions_response = self.interact_with_task(task_name, instruct_command)
+                sessions_list.append({'task_name': task_name, instruct_command: list_sessions_response[instruct_command]})
+        return sessions_list
+    
+    def kill_metasploit_session(self, task_name, session_id, instruct_instance=None):
+        instruct_command = 'kill_metasploit_session'
         instruct_args = {'session_id': session_id}
-        run_session_command_response = self.interact_with_task(task_name, instruct_command, instruct_instance, instruct_args)
-        return run_session_command_response
+        response = self.interact_with_task(task_name, instruct_command, instruct_instance, instruct_args)
+        return response
+    
+    def verify_metasploit_session(self, task_name, session_id, instruct_instance=None):
+        instruct_command = 'list_metasploit_sessions'
+        response = self.interact_with_task(task_name, instruct_command, instruct_instance)
+        for session in response[instruct_command]:
+            if session_id == session['session_id']:
+                return session
+            else:
+                return False
 
-    def get_agents(self, task_name):
-        instruct_command = 'get_agents'
-        agents_list = self.interact_with_task(task_name, instruct_command)
+    def list_empire_agents(self, task_name=None):
+        agents_list = []
+        list_tasks_response = self.list_tasks(task_name_contains=task_name, task_type='powershell_empire')
+        if len(list_tasks_response['tasks']) != 0:
+            for task in list_tasks_response['tasks']:
+                task_name=task['task_name']
+                instruct_command = 'list_empire_agents'
+                list_agents_response = self.interact_with_task(task_name, instruct_command)
+                agents_list.append({'task_name': task_name, instruct_command: list_agents_response[instruct_command]})
         return agents_list
-
-    def verify_agent(self, task_name, agent_name, instruct_instance=None):
-        instruct_command = 'get_agents'
+    
+    def kill_empire_agent(self, task_name, agent_name, instruct_instance=None):
+        if instruct_instance is None:
+            instruct_instance = ''.join(random.choice(string.ascii_letters) for i in range(6))
+        instruct_command = 'kill_empire_agent'
         instruct_args = {'Name': agent_name}
-        agents_list = self.interact_with_task(task_name, instruct_command, instruct_instance, instruct_args)
-        for agent in agents_list['agents']:
+        response = self.interact_with_task(task_name, instruct_command, instruct_instance, instruct_args)
+        return response
+
+    def verify_empire_agent(self, task_name, agent_name, instruct_instance=None):
+        instruct_command = 'list_empire_agents'
+        instruct_args = {'Name': agent_name}
+        response = self.interact_with_task(task_name, instruct_command, instruct_instance, instruct_args)
+        for agent in response[instruct_command]:
             if agent_name == agent['name']:
                 return agent
             else:
                 return False
 
-    def execute_agent_shell_command(self, task_name, agent_name, command, wait_for_results=None, beginning_string=None, completion_string=None, instruct_instance=None):
+    def list_empire_agent_task_ids(self, task_name, agent_name):
+        instruct_args = {'Name': agent_name}
+        agent_task_ids = self.interact_with_task(task_name, 'list_empire_agent_task_ids', instruct_args=instruct_args)
+        if 'task_id_list' in agent_task_ids:
+            return agent_task_ids['task_id_list']
+        else:
+            return agent_task_ids
+
+    def get_empire_agent_results(self, task_name, agent_name, task_id):
+        instruct_args = {'Name': agent_name, 'task_id': task_id}
+        agent_results = self.interact_with_task(task_name, 'get_empire_agent_results', instruct_args=instruct_args)
+        if 'results' in agent_results and agent_results['results']:
+            tmp_results = json.loads(zlib.decompress(base64.b64decode(agent_results['results'].encode())).decode())
+            results = tmp_results['results']
+        else:
+            results = []
+        return results
+    
+    def execute_empire_agent_shell_command(self, task_name, agent_name, command, wait_for_results=None, beginning_string=None, completion_string=None, instruct_instance=None):
         if instruct_instance is None:
             instruct_instance = ''.join(random.choice(string.ascii_letters) for i in range(6))
-        instruct_args = {'Name': agent_name, 'command': command}
-        command_response = self.interact_with_task(task_name, 'execute_agent_shell_command', instruct_instance, instruct_args)
-        if command_response['outcome'] == 'success':
-            command_task_id = command_response['execute_agent_shell_command']['taskID']
+        orig_instruct_command = 'execute_empire_agent_shell_command'
+        orig_instruct_args = {'Name': agent_name, 'command': command}
+        response = self.interact_with_task(task_name, orig_instruct_command, instruct_instance, orig_instruct_args)
+        if response['outcome'] == 'success':
+            command_task_id = response[orig_instruct_command]['taskID']
         else:
-            return command_response
+            return response
         if wait_for_results and wait_for_results.lower() != 'false':
             try:
                 outcome = None
                 results = None
                 while not results:
                     self.wait_for_idle_task(task_name)
-                    instruct_args = {'Name': agent_name, 'task_id': command_task_id}
-                    command_results = self.interact_with_task(task_name, 'get_shell_command_results', instruct_instance, instruct_args)
-                    if command_results['outcome'] == 'success' and command_results['get_shell_command_results']:
-                        tmp_results = json.loads(zlib.decompress(base64.b64decode(command_results['get_shell_command_results'].encode())).decode())
+                    res_instruct_command = 'get_empire_agent_results'
+                    res_instruct_args = {'Name': agent_name, 'task_id': command_task_id}
+                    command_results = self.interact_with_task(task_name, res_instruct_command, instruct_instance, res_instruct_args)
+                    if command_results['outcome'] == 'success' and command_results[res_instruct_command]:
+                        tmp_results = json.loads(zlib.decompress(base64.b64decode(command_results[res_instruct_command].encode())).decode())
                         if tmp_results['results'] is not None:
                             if beginning_string is not None and completion_string is not None:
                                 re_string = re.compile('(' + beginning_string + '.*' + completion_string + ')')
@@ -902,41 +955,43 @@ class Connect:
                                 results = tmp_results['results']
                     else:
                         outcome = 'failed'
-                        results = f'get_shell_command_results for execute_agent_shell_command failed with error: {command_results}'
+                        results = f'{res_instruct_command} for {orig_instruct_command} failed with error: {command_results}'
                     if not results:
                         t.sleep(10)
-                output = {'outcome': outcome, 'execute_agent_shell_command': results}
+                output = {'outcome': outcome, orig_instruct_command: results}
                 return output
             except Exception as e:
                 outcome = 'failed'
                 results = f'unable to retrieve results for agent task ID {command_task_id} with error: {e}'
-                output = {'outcome': outcome, 'execute_agent_shell_command': results}
+                output = {'outcome': outcome, orig_instruct_command: results}
                 return output
         else:
-            return command_response
-    
-    def execute_agent_module(self, task_name, agent_name, module, module_args=None, wait_for_results=None, beginning_string=None, completion_string=None, instruct_instance=None):
+            return response
+
+    def execute_empire_agent_module(self, task_name, agent_name, module, module_args=None, wait_for_results=None, beginning_string=None, completion_string=None, instruct_instance=None):
         if instruct_instance is None:
             instruct_instance = ''.join(random.choice(string.ascii_letters) for i in range(6))
-        instruct_args = {'Agent': agent_name, 'Name': module}
+        orig_instruct_command = 'execute_empire_agent_module'
+        orig_instruct_args = {'Agent': agent_name, 'Name': module}
         if module_args:
             for k, v in module_args.items():
-                instruct_args[k] = v
-        module_response = self.interact_with_task(task_name, 'execute_agent_module', instruct_instance, instruct_args)
-        if module_response['outcome'] == 'success':
-            module_task_id = module_response['execute_agent_module']['taskID']
+                orig_instruct_args[k] = v
+        response = self.interact_with_task(task_name, orig_instruct_command, instruct_instance, orig_instruct_args)
+        if response['outcome'] == 'success':
+            module_task_id = response[orig_instruct_command]['taskID']
         else:
-            return module_response
+            return response
         if wait_for_results and wait_for_results.lower() != 'false':
             try:
                 outcome = None
                 results = None
                 while not results:
                     self.wait_for_idle_task(task_name)
-                    instruct_args = {'Name': agent_name, 'task_id': module_task_id}
-                    module_results = self.interact_with_task(task_name, 'get_shell_command_results', instruct_instance, instruct_args)
-                    if module_results['outcome'] == 'success' and module_results['get_shell_command_results']:
-                        tmp_results = json.loads(zlib.decompress(base64.b64decode(module_results['get_shell_command_results'].encode())).decode())
+                    res_instruct_command = 'get_empire_agent_results'
+                    res_instruct_args = {'Name': agent_name, 'task_id': module_task_id}
+                    module_results = self.interact_with_task(task_name, res_instruct_command, instruct_instance, res_instruct_args)
+                    if module_results['outcome'] == 'success' and module_results[res_instruct_command]:
+                        tmp_results = json.loads(zlib.decompress(base64.b64decode(module_results[res_instruct_command].encode())).decode())
                         if tmp_results['results'] is not None and 'Job started:' not in tmp_results['results']:
                             if beginning_string is not None and completion_string is not None:
                                 re_string = re.compile('(' + beginning_string + '.*' + completion_string + ')')
@@ -952,18 +1007,18 @@ class Connect:
                                 results = tmp_results['results']
                     else:
                         outcome = 'failed'
-                        results = f'get_shell_command_results for execute_agent_module failed with error: {module_results}'
+                        results = f'{res_instruct_command} for {orig_instruct_command} failed with error: {module_results}'
                     if not results:
                         t.sleep(10)
-                output = {'outcome': outcome, 'execute_agent_module': results}
+                output = {'outcome': outcome, orig_instruct_command: results}
                 return output
             except Exception as e:
                 outcome = 'failed'
                 results = f'unable to retrieve results for agent task ID {module_task_id} with error: {e}'
-                output = {'outcome': outcome, 'execute_agent_module': results}
+                output = {'outcome': outcome, orig_instruct_command: results}
                 return output
         else:
-            return module_response
+            return response
     
     def execute_trigger(self, trigger_name, execute_command, execute_command_args=None, execute_command_timeout=None, filter_command=None,
                         filter_command_args=None, filter_command_timeout=None):
@@ -984,63 +1039,45 @@ class Connect:
             payload['detail']['filter_command_args'] = filter_command_args
         if filter_command_timeout:
             payload['detail']['filter_command_timeout'] = filter_command_timeout
-        execute_trigger_response = self.post(self.trigger_executor_api_endpoint, payload)
-        return execute_trigger_response
+        response = self.post(self.trigger_executor_api_endpoint, payload)
+        return response
     
     def get_trigger_results(self, trigger_name, filter_command=None, execute_command=None, start_time=None, end_time=None):
         payload = {
             'action': 'get_results',
             'detail': {'trigger_name': trigger_name, 'start_time': start_time, 'end_time': end_time}
         }
-        get_trigger_results_response = self.post(self.trigger_executor_api_endpoint, payload)
-        if 'queue' not in get_trigger_results_response:
-            return get_trigger_results_response
+        response = self.post(self.trigger_executor_api_endpoint, payload)
+        if 'queue' not in response:
+            return response
         filtered_results = []
         if not execute_command and not filter_command:
-            for result in get_trigger_results_response['queue']:
+            for result in response['queue']:
                 filtered_results.append(result)
         if filter_command and not execute_command:
-            for result in get_trigger_results_response['queue']:
+            for result in response['queue']:
                 if result['filter_command'] == filter_command:
                     filtered_results.append(result)
         if execute_command and not filter_command:
-            for result in get_trigger_results_response['queue']:
+            for result in response['queue']:
                 if result['execute_command'] == execute_command:
                     filtered_results.append(result)
         if filter_command and execute_command:
-            for result in get_trigger_results_response['queue']:
+            for result in response['queue']:
                 if result['filter_command'] == filter_command and result['execute_command'] == execute_command:
                     filtered_results.append(result)
-        del get_trigger_results_response['queue']
-        get_trigger_results_response['queue'] = filtered_results
-        return get_trigger_results_response
-    
-    def get_agent_task_ids(self, task_name, agent_name):
-        instruct_args = {'Name': agent_name}
-        agent_task_ids = self.interact_with_task(task_name, 'get_task_id_list', instruct_args=instruct_args)
-        if 'task_id_list' in agent_task_ids:
-            return agent_task_ids['task_id_list']
-        else:
-            return agent_task_ids
-
-    def get_agent_results(self, task_name, agent_name, task_id):
-        instruct_args = {'Name': agent_name, 'task_id': task_id}
-        agent_results = self.interact_with_task(task_name, 'get_shell_command_results', instruct_args=instruct_args)
-        if 'results' in agent_results and agent_results['results']:
-            tmp_results = json.loads(zlib.decompress(base64.b64decode(agent_results['results'].encode())).decode())
-            results = tmp_results['results']
-        else:
-            results = []
-        return results
+        del response['queue']
+        response['queue'] = filtered_results
+        return response
 
     def wait_for_c2(self, task_name, time_skew=0):
         results = None
         existing_c2 = []
         time_skew_datetime = datetime.datetime.utcnow() - datetime.timedelta(minutes=int(time_skew))
         time_skew_string = time_skew_datetime.strftime('%m/%d/%Y %H:%M:%S')
-        get_task_results_response = self.get_task_results(task_name, end_time=time_skew_string)
-        if 'queue' in get_task_results_response:
-            for task_result in get_task_results_response['queue']:
+        response = self.get_task_results(task_name, end_time=time_skew_string)
+        if 'queue' in response:
+            for task_result in response['queue']:
                 instruct_command = task_result['instruct_command']
                 if instruct_command == 'agent_status_monitor' or instruct_command == 'session_status_monitor':
                     instruct_command_output = json.loads(task_result['instruct_command_output'])
@@ -1078,20 +1115,20 @@ class Connect:
             }
         }
 
-        register_task_response = self.post(self.remote_api_endpoint, payload)
-        return register_task_response
+        response = self.post(self.remote_api_endpoint, payload)
+        return response
 
     def get_commands(self, task_name):
         payload = {'command': 'get_commands', 'detail': {'task_name': task_name}}
 
-        commands_response = self.post(self.remote_api_endpoint, payload)
-        return commands_response
+        response = self.post(self.remote_api_endpoint, payload)
+        return response
 
     def post_response(self, results):
         payload = {'command': 'post_results', 'results': results}
 
-        post_response = self.post(self.remote_api_endpoint, payload)
-        return post_response
+        response = self.post(self.remote_api_endpoint, payload)
+        return response
 
     def sync_workspace(self, sync_direction, sync_path):
         file_list = []
@@ -1101,7 +1138,7 @@ class Connect:
             if 'files' in list_response:
                 for f in list_response['files']:
                     file_list.append(f)
-                    payload = {'resource': 'workspace', 'command': 'get', 'detail': {'filename': f}}
+                    payload = {'resource': 'workspace', 'command': 'get', 'detail': {'file_name': f}}
                     get_file_response = self.post(self.manage_api_endpoint, payload)
                     decoded_file = base64.b64decode(get_file_response['file_contents'])
                     new_file = None
@@ -1123,7 +1160,7 @@ class Connect:
                         f.close()
                         payload = {
                             'resource': 'workspace', 'command': 'create', 'detail': {
-                                'filename': file_name, 'file_contents': encoded_file
+                                'file_name': file_name, 'file_contents': encoded_file
                             }
                         }
                         self.post(self.manage_api_endpoint, payload)

--- a/havoc/__init__.py
+++ b/havoc/__init__.py
@@ -874,13 +874,17 @@ class Connect:
 
     def list_empire_agents(self, task_name=None):
         agents_list = []
-        list_tasks_response = self.list_tasks(task_name_contains=task_name, task_type='powershell_empire')
-        if len(list_tasks_response['tasks']) != 0:
-            for task in list_tasks_response['tasks']:
-                task_name=task['task_name']
-                instruct_command = 'list_empire_agents'
-                list_agents_response = self.interact_with_task(task_name, instruct_command)
-                agents_list.append({'task_name': task_name, instruct_command: list_agents_response[instruct_command]})
+        if task_name is None:
+            list_tasks_response = self.list_tasks(task_name_contains=task_name, task_type='powershell_empire')
+            if len(list_tasks_response['tasks']) != 0:
+                for task in list_tasks_response['tasks']:
+                    task_name=task['task_name']
+                    instruct_command = 'list_empire_agents'
+                    list_agents_response = self.interact_with_task(task_name, instruct_command)
+                    agents_list.append({'task_name': task_name, instruct_command: list_agents_response[instruct_command]})
+        else:
+            list_agents_response = self.interact_with_task(task_name, instruct_command)
+            agents_list.append({'task_name': task_name, instruct_command: list_agents_response[instruct_command]})
         return agents_list
     
     def kill_empire_agent(self, task_name, agent_name, instruct_instance=None):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="havoc",
-    version="1.0.1",
+    version="1.0.2",
     packages=find_packages(),
 
     # Project requires Python 3.7 or higher but less than Python 4


### PR DESCRIPTION
Cleaned up install process.
Added active_resources list to deployment table.
Added uninstall gates that check deployment's active_resources to prevent uninstall leaving orphaned resources.
Changed agent and session related commands to reflect their PowerShell Empire and Metasploit association.
Added support for file upload/download to/from PowerShell Empire agents.
Other minor fixes/improvements:

get_file: attempt to download file that exceeds max file size results in a more informative error that includes a recommendation for using create_workspace_get_url command to generate a presigned URL that allows the large file to be downloaded directly from S3.
Added kill_empire_agent command.
Fixed Listener task and portgroup mappings.
Fixed output formatting of activity_report script.